### PR TITLE
Split CI/CD workflow in client/server

### DIFF
--- a/.github/workflows/cicd_client.yml
+++ b/.github/workflows/cicd_client.yml
@@ -1,0 +1,23 @@
+name: Client
+
+on:
+  pull_request:
+    paths:
+      - 'client/**'
+  push:
+    branches:
+      - main
+    paths:
+      - 'client/**'
+
+jobs:
+  client:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup
+      run: cd client && cargo check
+    - name: Run Lint
+      run: cd client && cargo clippy -- -Dwarnings
+    - name: Test
+      run: cd client && cargo test

--- a/.github/workflows/cicd_client.yml
+++ b/.github/workflows/cicd_client.yml
@@ -16,8 +16,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup
-      run: cd client && cargo check
+      run: cd client && cargo check --verbose
     - name: Run Lint
-      run: cd client && cargo clippy -- -Dwarnings
+      run: cd client && cargo clippy -- -Dwarnings --verbose
     - name: Test
-      run: cd client && cargo test
+      run: cd client && cargo test --verbose

--- a/.github/workflows/cicd_server.yml
+++ b/.github/workflows/cicd_server.yml
@@ -1,24 +1,16 @@
-
-name: CI/CD
+name: Server
 
 on:
   pull_request:
+    paths:
+      - 'server/**'
   push:
     branches:
       - main
+    paths:
+      - 'server/**'
 
 jobs:
-  client:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Setup
-      run: cd client && cargo check
-    - name: Run Lint
-      run: cd client && cargo clippy -- -Dwarnings
-    - name: Test
-      run: cd client && cargo test
-
   server:
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/cicd_server.yml
+++ b/.github/workflows/cicd_server.yml
@@ -35,13 +35,13 @@ jobs:
         cd server
         cargo install diesel_cli --no-default-features --features postgres
     - name: Check
-      run: cd server && cargo check
+      run: cd server && cargo check --verbose
     - name: Lint
-      run: cd server && cargo clippy -- -Dwarnings
+      run: cd server && cargo clippy -- -Dwarnings --verbose
     - name: Test
       env:
         DATABASE_URL: postgres://postgres:postgres@localhost/thermit-server-test
       run: |
         cd server
         diesel migration run
-        cargo test
+        cargo test --verbose

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # thermit
 An exciting and inspiring messenger written in Rust
+
+[![Client](https://github.com/eisen-oxid/thermit/actions/workflows/cicd_client.yml/badge.svg)](https://github.com/eisen-oxid/thermit/actions/workflows/cicd_client.yml)
+[![Server](https://github.com/eisen-oxid/thermit/actions/workflows/cicd_server.yml/badge.svg)](https://github.com/eisen-oxid/thermit/actions/workflows/cicd_server.yml)


### PR DESCRIPTION
This splits the CI/CD workflow in two files, which allows running the specific pipelines only if files in their directory have changed. It also adds status badges to the readme, which currently don't show.