### PR TITLE
Fix #36 by adding a test database

### DIFF
--- a/.github/workflows/cicd_server.yml
+++ b/.github/workflows/cicd_server.yml
@@ -41,6 +41,7 @@ jobs:
     - name: Test
       env:
         DATABASE_URL: postgres://postgres:postgres@localhost/thermit-server-test
+        TEST_DATABASE_URL: postgres://postgres:postgres@localhost/thermit-server-test
       run: |
         cd server
         diesel migration run

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,4 +1,5 @@
 DATABASE_URL=postgres://thermit-server:thermit-server@localhost/thermit-server
+TEST_DATABASE_URL=postgres://thermit-server:thermit-server@localhost/thermit-server-test
 SERVER_IP=0.0.0.0
 SERVER_PORT=8000
 RUST_LOG=info,actix_web=info

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -554,6 +554,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "diesel_migrations"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf3cde8413353dc7f5d72fa8ce0b99a560a359d2c5ef1e5817ca731cd9008f4c"
+dependencies = [
+ "migrations_internals",
+ "migrations_macros",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1019,6 +1029,27 @@ name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+
+[[package]]
+name = "migrations_internals"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b4fc84e4af020b837029e017966f86a1c2d5e83e64b589963d5047525995860"
+dependencies = [
+ "diesel",
+]
+
+[[package]]
+name = "migrations_macros"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9753f12909fd8d923f75ae5c3258cae1ed3c8ec052e1b38c93c21a6d157f789c"
+dependencies = [
+ "migrations_internals",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "mime"
@@ -1502,6 +1533,7 @@ dependencies = [
  "actix-web",
  "derive_more",
  "diesel",
+ "diesel_migrations",
  "dotenv",
  "env_logger",
  "pwhash",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -11,6 +11,7 @@ actix-web = "3"
 serde = { version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 diesel = { version = "1.4.5", features = ["postgres", "r2d2", "uuidv07"] }
+diesel_migrations = "1.4.0"
 dotenv = "0.15.0"
 r2d2 = "0.8.8"
 derive_more = "0.99.2"

--- a/server/docker/postgres.sh
+++ b/server/docker/postgres.sh
@@ -4,9 +4,8 @@ sudo docker run \
   -p 127.0.0.1:5432:5432 \
   -d \
   --name postgres \
-  -e POSTGRES_USER=thermit-server \
-  -e POSTGRES_PASSWORD=thermit-server \
-  -e POSTGRES_DB=thermit-server \
+  -e POSTGRES_USERS="thermit-server:thermit-server" \
+  -e POSTGRES_DATABASES="thermit-server:thermit-server|thermit-server-test:thermit-server" \
   -v thermit-server:/var/lib/postgresql/data \
   --rm \
-  postgres:12
+  lmmdock/postgres-multi

--- a/server/src/test_helpers.rs
+++ b/server/src/test_helpers.rs
@@ -1,11 +1,13 @@
 use crate::room::{Room, RoomData};
 use crate::user::{User, UserData};
 use diesel::prelude::*;
+use diesel_migrations::*;
 
 pub fn connection() -> PgConnection {
-    let url = dotenv::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let url = dotenv::var("TEST_DATABASE_URL").expect("TEST_DATABASE_URL must be set");
     let conn = PgConnection::establish(&url).unwrap();
     conn.begin_test_transaction().unwrap();
+    run_pending_migrations(&conn).unwrap();
     conn
 }
 


### PR DESCRIPTION
Closes #36 

**Note:** If you want to test this locally, use your IDE of choice (e.g. CLion) and connect to the database to create the `thermit-server-test` or whatever database manually. Alternatively, you can also issue `docker volume rm thermit-server` and run `docker/postgres.sh` again. Running `docker/postgres.sh` alone won't change anything, as the database is initialized already.